### PR TITLE
[#49] Respect ignore at `single_use_hrls` rule

### DIFF
--- a/priv/test_files/single_use_hrls/include/ignored.hrl
+++ b/priv/test_files/single_use_hrls/include/ignored.hrl
@@ -1,3 +1,3 @@
--hank ignore.
+-hank(ignore).
 
 -define(HEADER_IGNORED, "this header file is included at include_ignored.erl").

--- a/priv/test_files/single_use_hrls/include/ignored.hrl
+++ b/priv/test_files/single_use_hrls/include/ignored.hrl
@@ -1,0 +1,3 @@
+-hank ignore.
+
+-define(HEADER_IGNORED, "this header file is included at include_ignored.erl").

--- a/priv/test_files/single_use_hrls/src/include_ignored.erl
+++ b/priv/test_files/single_use_hrls/src/include_ignored.erl
@@ -1,0 +1,4 @@
+-module(include_ignored).
+
+-include("ignored.hrl").
+-include("multi.hrl").

--- a/test/single_use_hrls_SUITE.erl
+++ b/test/single_use_hrls_SUITE.erl
@@ -1,10 +1,10 @@
 -module(single_use_hrls_SUITE).
 
 -export([all/0, init_per_testcase/2, end_per_testcase/2]).
--export([only_hrls/1, single_use/1, respects_ignore/1]).
+-export([only_hrls/1, single_use/1, respects_ignore/1, alltogether/1]).
 
 all() ->
-    [only_hrls, single_use, respects_ignore].
+    [only_hrls, single_use, respects_ignore, alltogether].
 
 init_per_testcase(_, Config) ->
     hank_test_utils:init_per_testcase(Config, "single_use_hrls").
@@ -28,15 +28,15 @@ single_use(_) ->
          "include/single.hrl",
          "src/include_multi.erl",
          "src/include_single.erl"],
-    [#{file := "single.hrl",
+    [#{file := "include/single.hrl",
        line := 0,
        text := <<"This header file is only included at: src/include_single.erl">>}] =
         analyze(Files),
     ok.
 
-%% @doc Hank respects the `-ignore` attribute in a header file
+%% @doc Hank respects the `ignore` attribute in a header file
 respects_ignore(_) ->
-    ct:comment("It should not detect include/ignored.hrl because is ignored"
+    ct:comment("It should not detect include/ignored.hrl because is ignored "
                "although it's only included at src/include_ignored.erl"),
     Files =
         ["include/multi.hrl",
@@ -44,6 +44,23 @@ respects_ignore(_) ->
          "src/include_multi.erl",
          "src/include_ignored.erl"],
     [] = analyze(Files),
+    ok.
+
+%% @doc Hank finds and ignores accordingly
+alltogether(_) ->
+    ct:comment("It should detect include/single.hrl because it's only included "
+               "at src/include_single.erl and not detect include/ignored.hrl"),
+    Files =
+        ["include/multi.hrl",
+         "include/single.hrl",
+         "include/ignored.hrl",
+         "src/include_multi.erl",
+         "src/include_single.erl",
+         "src/include_ignored.erl"],
+    [#{file := "include/single.hrl",
+       line := 0,
+       text := <<"This header file is only included at: src/include_single.erl">>}] =
+        analyze(Files),
     ok.
 
 analyze(Files) ->

--- a/test/single_use_hrls_SUITE.erl
+++ b/test/single_use_hrls_SUITE.erl
@@ -1,10 +1,10 @@
 -module(single_use_hrls_SUITE).
 
 -export([all/0, init_per_testcase/2, end_per_testcase/2]).
--export([only_hrls/1, single_use/1]).
+-export([only_hrls/1, single_use/1, respects_ignore/1]).
 
 all() ->
-    [only_hrls, single_use].
+    [only_hrls, single_use, respects_ignore].
 
 init_per_testcase(_, Config) ->
     hank_test_utils:init_per_testcase(Config, "single_use_hrls").
@@ -32,6 +32,18 @@ single_use(_) ->
        line := 0,
        text := <<"This header file is only included at: src/include_single.erl">>}] =
         analyze(Files),
+    ok.
+
+%% @doc Hank respects the `-ignore` attribute in a header file
+respects_ignore(_) ->
+    ct:comment("It should not detect include/ignored.hrl because is ignored"
+               "although it's only included at src/include_ignored.erl"),
+    Files =
+        ["include/multi.hrl",
+         "include/ignored.hrl",
+         "src/include_multi.erl",
+         "src/include_ignored.erl"],
+    [] = analyze(Files),
     ok.
 
 analyze(Files) ->


### PR DESCRIPTION
### From: https://github.com/AdRoll/rebar3_hank/pull/42

Resolves the `bug` to take into account the `ignore` attribute.