### PR TITLE
[#67] Adding support to ignore files that don't exist on filesystem

### DIFF
--- a/priv/test_files/single_use_hrls/src/include_missing.erl
+++ b/priv/test_files/single_use_hrls/src/include_missing.erl
@@ -1,0 +1,4 @@
+-module(include_missing).
+
+-include("missing.hrl").
+-include("multi.hrl").

--- a/src/hank_utils.erl
+++ b/src/hank_utils.erl
@@ -6,7 +6,8 @@
 
 -export([macro_arity/1, macro_name/1, parse_macro_name/1, macro_definition_name/1,
          function_description/1, attr_name/1, ast_has_attrs/2, node_has_attrs/2, attr_args/3,
-         attr_args/2, attr_args_concrete/2, implements_behaviour/1, paths_match/2, format_text/2]).
+         attr_args/2, attr_args_concrete/2, implements_behaviour/1, node_line/1, paths_match/2,
+         format_text/2]).
 
 %% @doc Get the macro arity of given Node
 -spec macro_arity(erl_syntax:syntaxTree()) -> none | pos_integer().
@@ -115,6 +116,12 @@ attr_args_concrete(AST, AttrName) ->
 -spec implements_behaviour(erl_syntax:forms()) -> boolean().
 implements_behaviour(AST) ->
     ast_has_attrs(AST, [behaviour, behavior]).
+
+%% @doc Returns the line number of the given node
+-spec node_line(erl_syntax:syntaxTree()) -> non_neg_integer().
+node_line(Node) ->
+    erl_anno:location(
+        erl_syntax:get_pos(Node)).
 
 %% @doc Whether one of the given paths is contained inside the other one or not.
 %%      It doesn't matter which one is contained at which other.

--- a/src/rebar3_hank_prv.erl
+++ b/src/rebar3_hank_prv.erl
@@ -45,7 +45,7 @@ do(State) ->
                 [];
             IgnoreRules ->
                 [{F, Rule}
-                 || {Wildcard, Rule} <- normalize(IgnoreRules), F <- ignore_wildcard(Wildcard)]
+                 || {Wildcard, Rule} <- normalize(IgnoreRules), F <- filelib:wildcard(Wildcard)]
         end,
     try hank:analyze(Files, IgnoredFiles, Rules, Context) of
         #{results := [], ignored := 0} ->
@@ -96,12 +96,3 @@ normalize(IgnoreRules) ->
                       {Wildcard, all}
               end,
               IgnoreRules).
-
-%% @doc Allows to ignore files that don't exist on filesystem
-ignore_wildcard(Wildcard) ->
-    case filelib:wildcard(Wildcard) of
-        [] ->
-            [Wildcard];
-        Files ->
-            Files
-    end.

--- a/src/rebar3_hank_prv.erl
+++ b/src/rebar3_hank_prv.erl
@@ -45,7 +45,7 @@ do(State) ->
                 [];
             IgnoreRules ->
                 [{F, Rule}
-                 || {Wildcard, Rule} <- normalize(IgnoreRules), F <- filelib:wildcard(Wildcard)]
+                 || {Wildcard, Rule} <- normalize(IgnoreRules), F <- ignore_wildcard(Wildcard)]
         end,
     try hank:analyze(Files, IgnoredFiles, Rules, Context) of
         #{results := [], ignored := 0} ->
@@ -96,3 +96,12 @@ normalize(IgnoreRules) ->
                       {Wildcard, all}
               end,
               IgnoreRules).
+
+%% @doc Allows to ignore files that don't exist on filesystem
+ignore_wildcard(Wildcard) ->
+    case filelib:wildcard(Wildcard) of
+        [] ->
+            [Wildcard];
+        Files ->
+            Files
+    end.

--- a/src/rules/single_use_hrl_attrs.erl
+++ b/src/rules/single_use_hrl_attrs.erl
@@ -124,5 +124,4 @@ record_name(Node, Type) ->
     erl_syntax:atom_value(RecordName).
 
 line(Node) ->
-    erl_anno:location(
-        erl_syntax:get_pos(Node)).
+    hank_utils:node_line(Node).

--- a/src/rules/single_use_hrls.erl
+++ b/src/rules/single_use_hrls.erl
@@ -38,16 +38,23 @@ build_include_list(FilesAndASTs) ->
                 FilesAndASTs).
 
 included_files(Files, AST) ->
-    [included_file_path(Files, IncludedFile) || IncludedFile <- include_paths(AST)].
-
-include_paths(AST) ->
-    hank_utils:attr_args_concrete(AST, include).
+    [included_file_path(Files, IncludedFile)
+     || IncludedFile <- hank_utils:attr_args_concrete(AST, include),
+        is_file_included(Files, IncludedFile) =/= false].
 
 included_file_path(Files, IncludedFile) ->
+    case is_file_included(Files, IncludedFile) of
+        false ->
+            IncludedFile;
+        IncludedFileWithPath ->
+            IncludedFileWithPath
+    end.
+
+is_file_included(Files, IncludedFile) ->
     MatchFunc = fun(File) -> hank_utils:paths_match(IncludedFile, File) end,
     case lists:search(MatchFunc, Files) of
         {value, IncludedFileWithPath} ->
             IncludedFileWithPath;
-        false ->
-            IncludedFile
+        _ ->
+            false
     end.

--- a/src/rules/unused_ignored_function_params.erl
+++ b/src/rules/unused_ignored_function_params.erl
@@ -42,9 +42,7 @@ set_result(_File, _) ->
     ok.
 
 check_function(FunctionNode) ->
-    Line =
-        erl_anno:location(
-            erl_syntax:get_pos(FunctionNode)),
+    Line = hank_utils:node_line(FunctionNode),
     FuncDesc = hank_utils:function_description(FunctionNode),
     Clauses = erl_syntax:function_clauses(FunctionNode),
     ComputedResults =

--- a/src/rules/unused_macros.erl
+++ b/src/rules/unused_macros.erl
@@ -39,9 +39,7 @@ do_analyze(File, AST) ->
 
 macro_definition_name_and_line(Node) ->
     {MacroName, MacroArity} = hank_utils:macro_definition_name(Node),
-    Line =
-        erl_anno:location(
-            erl_syntax:get_pos(Node)),
+    Line = hank_utils:node_line(Node),
     {MacroName, MacroArity, Line}.
 
 macro_application_name(Node) ->

--- a/src/rules/unused_record_fields.erl
+++ b/src/rules/unused_record_fields.erl
@@ -92,11 +92,9 @@ result(File, RecordName, FieldName, RecordDefinitions) ->
                 [_, RecordFields] = erl_syntax:attribute_arguments(RecordDefinition),
                 case find_record_field(FieldName, erl_syntax:tuple_elements(RecordFields)) of
                     false ->
-                        erl_anno:location(
-                            erl_syntax:get_pos(RecordDefinition));
+                        hank_utils:node_line(RecordDefinition);
                     {value, FieldDefinition} ->
-                        erl_anno:location(
-                            erl_syntax:get_pos(FieldDefinition))
+                        hank_utils:node_line(FieldDefinition)
                 end
         end,
     #{file => File,

--- a/test/hank_test_utils.erl
+++ b/test/hank_test_utils.erl
@@ -28,9 +28,15 @@ mock_context(Apps) ->
 analyze_and_sort(Files, Rules) ->
     analyze_and_sort(Files, Rules, mock_context(#{})).
 
-analyze_and_sort(Files, Rules, Context) ->
+analyze_and_sort(Files, Rules, Context) when is_map(Context) ->
+    analyze_and_sort(Files, [], Rules, Context);
+analyze_and_sort(Files, IgnoredFiles, Rules) ->
+    analyze_and_sort(Files, IgnoredFiles, Rules, mock_context(#{})).
+
+analyze_and_sort(Files, IgnoredFiles, Rules, Context) ->
+    Results = hank:analyze(Files, IgnoredFiles, Rules, Context),
     lists:sort(
-        maps:get(results, hank:analyze(Files, [], Rules, Context))).
+        maps:get(results, Results)).
 
 set_cwd(RelativePathOrFilename) ->
     ok = file:set_cwd(abs_test_path(RelativePathOrFilename)).

--- a/test/single_use_hrls_SUITE.erl
+++ b/test/single_use_hrls_SUITE.erl
@@ -49,12 +49,13 @@ respects_ignore(_) ->
     [] = analyze(Files, [{"include/single.hrl", all}]),
     ok.
 
-%% @doc Hank ignores header files that are ignored and missing from filesystem
+%% @doc Hank ignores header files that aren't present in the list of analyzed files
 ignores_missing_files(_) ->
-    ct:comment("It should not detect missing.hrl because is ignored although "
-               "it doesn't exist and is only included at src/include_missing.erl"),
+    ct:comment("It should not detect missing.hrl because it isn't present in "
+               "the list of files analyzed by Hank, although is only included "
+               "at src/include_missing.erl"),
     Files = ["include/multi.hrl", "src/include_multi.erl", "src/include_missing.erl"],
-    [] = analyze(Files, [{"missing.hrl", all}]),
+    [] = analyze(Files),
     ok.
 
 %% @doc Hank finds and ignores accordingly
@@ -78,7 +79,7 @@ alltogether(_) ->
        line := 0,
        text :=
            <<"This header file is only included at: src/include_unicode_"/utf8, _/binary>>}] =
-        analyze(Files, [{"missing.hrl", all}]),
+        analyze(Files),
     ok.
 
 analyze(Files) ->

--- a/test/single_use_hrls_SUITE.erl
+++ b/test/single_use_hrls_SUITE.erl
@@ -1,10 +1,11 @@
 -module(single_use_hrls_SUITE).
 
 -export([all/0, init_per_testcase/2, end_per_testcase/2]).
--export([only_hrls/1, single_use/1, respects_ignore/1, alltogether/1]).
+-export([only_hrls/1, single_use/1, respects_ignore/1, ignores_missing_files/1,
+         alltogether/1]).
 
 all() ->
-    [only_hrls, single_use, respects_ignore, alltogether].
+    [only_hrls, single_use, respects_ignore, ignores_missing_files, alltogether].
 
 init_per_testcase(_, Config) ->
     hank_test_utils:init_per_testcase(Config, "single_use_hrls").
@@ -34,16 +35,26 @@ single_use(_) ->
         analyze(Files),
     ok.
 
-%% @doc Hank respects the `ignore` attribute in a header file
+%% @doc Hank respects the `ignore` attribute in a header file and at `rebar.config`
 respects_ignore(_) ->
     ct:comment("It should not detect include/ignored.hrl because is ignored "
                "although it's only included at src/include_ignored.erl"),
     Files =
         ["include/multi.hrl",
+         "include/single.hrl",
          "include/ignored.hrl",
          "src/include_multi.erl",
+         "src/include_single.erl",
          "src/include_ignored.erl"],
-    [] = analyze(Files),
+    [] = analyze(Files, [{"include/single.hrl", all}]),
+    ok.
+
+%% @doc Hank ignores header files that are ignored and missing from filesystem
+ignores_missing_files(_) ->
+    ct:comment("It should not detect missing.hrl because is ignored although "
+               "it doesn't exist and is only included at src/include_missing.erl"),
+    Files = ["include/multi.hrl", "src/include_multi.erl", "src/include_missing.erl"],
+    [] = analyze(Files, [{"missing.hrl", all}]),
     ok.
 
 %% @doc Hank finds and ignores accordingly
@@ -57,7 +68,8 @@ alltogether(_) ->
          "include/ignored.hrl",
          "src/include_multi.erl",
          "src/include_single.erl",
-         "src/include_ignored.erl"
+         "src/include_ignored.erl",
+         "src/include_missing.erl"
          | filelib:wildcard("src/include_unicode_*.erl")],
     [#{file := "include/single.hrl",
        line := 0,
@@ -66,8 +78,11 @@ alltogether(_) ->
        line := 0,
        text :=
            <<"This header file is only included at: src/include_unicode_"/utf8, _/binary>>}] =
-        analyze(Files),
+        analyze(Files, [{"missing.hrl", all}]),
     ok.
 
 analyze(Files) ->
-    hank_test_utils:analyze_and_sort(Files, [single_use_hrls]).
+    analyze(Files, []).
+
+analyze(Files, IgnoredFiles) ->
+    hank_test_utils:analyze_and_sort(Files, IgnoredFiles, [single_use_hrls]).


### PR DESCRIPTION
The main problem with issue #67 is that the `gpb.hrl` file doesn't exist on filesystem in the expected location in where Hank looks for files to analyze (it's inside `./_build/default/plugins/gpb/include` as described in the issue).

The solution was to allow to ignore files that aren't found through `filelib:wildcard/1` at `rebar3_hank_prv:do/1`.