### PR TITLE
[#68] Adding support to ignore specific items

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,18 @@ The plugin supports the following configuration options in the `hank` section of
     - You can also ignore a specific file adding the attribute `-hank ignore.` to it.
     - And you can ignore specific rules adding the attribute `-hank [hank_rule:t()].` with the list of rules you want to ignore.
 
+### Ignore specific rule items
+You can even ignore specific rule items with the `-hank` attribute by giving extra _ignore specifications_ for each rule, example:
+```
+-hank([unused_macros,  %% Will ignore the whole rule within the module
+       {unused_callbacks, cb_func_name_to_ignore}  %% Will ignore the given callback funcion name within the module
+       {unnecessary_function_arguments,  %% You can give a list of multiple specs (or a single one like above)
+           [{ignore_me, 2},  %% Will ignore any unused argument from `ignore_me/2` within the module
+            {ignore_me_too, 3, 2},  %% Will ignore the 2nd argument from `ignore_me_too/3` within the module
+            ignore_me_again]}]). %% Will ignore any unused argument from any `ignore_me_again/x` within the module (no matter the arity)
+```
+Refer to each rule documentation for further details.
+
 ## Rules
 
 Find detailed information about the rules provided by Hank in [hex docs](https://hexdocs.pm/rebar3_hank/).

--- a/priv/overview.edoc
+++ b/priv/overview.edoc
@@ -1,9 +1,8 @@
 ** this is the overview.doc file for rebar3_hank **
 
-@copyright (c) 2020 NextRoll Inc.
 @author Brujo <brujo.benavides@nextroll.com>
 @author Pablo <pablo.brudnick@nextroll.com>
-@author Diego <diego.calero@nextroll.com>
+@author Diego <dcalero@fiqus.coop>
 @title Hank: The Erlang Dead Code Cleaner
 @doc This project provides a rebar3 plugin to use the <code>rebar3 hank</code> command.
      Use it to find dead code in your applications.

--- a/priv/test_files/ignore/specific_ignore.erl
+++ b/priv/test_files/ignore/specific_ignore.erl
@@ -1,10 +1,25 @@
 -module(specific_ignore).
 
--hank([unused_macros]).
+-hank([unused_macros,
+       {unnecessary_function_arguments,
+           [{no_ignore, 2},
+            {do_ignore, 1, 1},
+            do_ignore_me_too]}]).
 
 -define(UNUSED_MACRO, unused_macro).
 
--export([no_ignore/0]).
+-export([no_ignore/2, do_ignore/1,
+         do_ignore_me_too/1, do_ignore_me_too/2, do_ignore_me_too/3]).
 
 no_ignore(_, _) ->
     no_ignore.
+
+do_ignore(_Arg1) ->
+    ok.
+
+do_ignore_me_too(_Arg1) ->
+    ok.
+do_ignore_me_too(_Arg1, _Arg2) ->
+    ok.
+do_ignore_me_too(_Arg1, _Arg2, _Arg3) ->
+    ok.

--- a/priv/test_files/unnecessary_function_arguments/ignore.erl
+++ b/priv/test_files/unnecessary_function_arguments/ignore.erl
@@ -1,0 +1,31 @@
+-module(ignore).
+
+-export([ignore_arg2/3, ignore_arg2/2, ignore_whole_func3/3,
+         ignore_whole_func/1, ignore_whole_func/2]).
+
+-hank([{unnecessary_function_arguments,
+          [{ignore_arg2, 3, 2},
+           {ignore_arg2, 2, 1},
+           {ignore_whole_func3, 3},
+           ignore_whole_func]}]).
+
+%% Arg2 is unused but ignored
+ignore_arg2(Arg1, _Arg2, Arg3) ->
+    Arg1 + Arg3.
+%% Arg1 and Arg2 are unused but just ignoring Arg1 for `ignore_arg2/2`
+ignore_arg2(_Arg1, _Arg2) ->
+    ok.
+
+%% A multi-clause function with unused 1st param
+ignore_whole_func3(_, _, undefined) ->
+    ok;
+ignore_whole_func3(_, Arg2, _) when is_binary(Arg2) ->
+    Arg2;
+ignore_whole_func3(_, _, Arg3) ->
+    Arg3.
+
+%% Same function names with different arities
+ignore_whole_func(_) ->
+    ok.
+ignore_whole_func(_, _) ->
+    ok.

--- a/src/hank_rule.erl
+++ b/src/hank_rule.erl
@@ -40,6 +40,9 @@ analyze(Rule, ASTs, Context) ->
 %% @doc Check if given rule should be ignored from results
 -spec is_ignored(t(), ignore_pattern(), [all | term()]) -> boolean().
 is_ignored(Rule, Pattern, IgnoredSpecs) ->
-    lists:any(fun(IgnoreSpec) -> IgnoreSpec =:= all orelse Rule:ignored(Pattern, IgnoreSpec)
+    lists:any(fun(IgnoreSpec) ->
+                 IgnoreSpec =:= all
+                 orelse IgnoreSpec =:= Pattern
+                 orelse Rule:ignored(Pattern, IgnoreSpec)
               end,
               IgnoredSpecs).

--- a/src/hank_utils.erl
+++ b/src/hank_utils.erl
@@ -4,9 +4,10 @@
 %% To allow erl_syntax:syntaxTree/0 type spec
 -elvis([{elvis_style, atom_naming_convention, #{regex => "^([a-zA-Z][a-z0-9]*_?)*$"}}]).
 
--export([macro_arity/1, macro_name/1, macro_definition_name/1, function_description/1,
-         application_node_to_mfa/1, attr_name/1, node_has_attrs/2, attr_args_concrete/2,
-         implements_behaviour/1, node_line/1, node_atoms/1, paths_match/2, format_text/2]).
+-export([macro_arity/1, macro_name/1, macro_definition_name/1, function_name/1,
+         function_description/1, application_node_to_mfa/1, attr_name/1, node_has_attrs/2,
+         attr_args_concrete/2, implements_behaviour/1, node_line/1, node_atoms/1, paths_match/2,
+         format_text/2]).
 
 %% @doc Get the macro arity of given Node
 -spec macro_arity(erl_syntax:syntaxTree()) -> none | pos_integer().
@@ -51,17 +52,21 @@ macro_definition_name(Node) ->
             {erl_syntax:atom_literal(MacroNameNode), none}
     end.
 
+%% @doc Get the function name of a given Function Node.
+-spec function_name(erl_syntax:syntaxTree()) -> string().
+function_name(Node) ->
+    FuncNameNode = erl_syntax:function_name(Node),
+    case erl_syntax:type(FuncNameNode) of
+        macro ->
+            [$? | macro_name(FuncNameNode)];
+        atom ->
+            erl_syntax:atom_name(FuncNameNode)
+    end.
+
 %% @doc Get the function definition name and arity of a given Function Node.
 -spec function_description(erl_syntax:syntaxTree()) -> string().
 function_description(Node) ->
-    FuncNameNode = erl_syntax:function_name(Node),
-    FuncName =
-        case erl_syntax:type(FuncNameNode) of
-            macro ->
-                [$? | macro_name(FuncNameNode)];
-            atom ->
-                erl_syntax:atom_name(FuncNameNode)
-        end,
+    FuncName = function_name(Node),
     FuncArity = erl_syntax:function_arity(Node),
     FuncName ++ [$/ | integer_to_list(FuncArity)].
 

--- a/src/rules/single_use_hrl_attrs.erl
+++ b/src/rules/single_use_hrl_attrs.erl
@@ -8,7 +8,7 @@
 
 -behaviour(hank_rule).
 
--export([analyze/2]).
+-export([analyze/2, ignored/2]).
 
 %% @doc This builds a list of header files with its attributes.
 %%      Then traverse the file ASTs mapping their macros and records
@@ -38,13 +38,15 @@ build_macro_result(HrlFile, {Macro, Line}, AttributesUsed) ->
         end,
     #{file => HrlFile,
       line => Line,
-      text => Text}.
+      text => Text,
+      pattern => undefined}.
 
 build_record_result(HrlFile, {Record, Line}, AttributesUsed) ->
     [File] = maps:get(Record, AttributesUsed),
     #{file => HrlFile,
       line => Line,
-      text => hank_utils:format_text("#~tp is used only at ~ts", [Record, File])}.
+      text => hank_utils:format_text("#~tp is used only at ~ts", [Record, File]),
+      pattern => undefined}.
 
 is_used_only_once({Key, _Line}, AttributesUsed) ->
     length(maps:get(Key, AttributesUsed, [])) == 1.
@@ -128,3 +130,10 @@ record_name(Node, Type) ->
 
 line(Node) ->
     hank_utils:node_line(Node).
+
+%% @todo Add ignore pattern support
+-spec ignored(hank_rule:ignore_pattern(), term()) -> boolean().
+ignored(undefined, _IgnoreSpec) ->
+    false; %% Remove this clause and just use the one below
+ignored(_Pattern, _IgnoreSpec) ->
+    true.

--- a/src/rules/single_use_hrls.erl
+++ b/src/rules/single_use_hrls.erl
@@ -5,7 +5,7 @@
 
 -behaviour(hank_rule).
 
--export([analyze/2]).
+-export([analyze/2, ignored/2]).
 
 %% @private
 -spec analyze(hank_rule:asts(), hank_context:t()) -> [hank_rule:result()].
@@ -17,7 +17,8 @@ set_result(HeaderFile, IncludedAtFile) ->
     #{file => HeaderFile,
       line => 0,
       text =>
-          hank_utils:format_text("This header file is only included at: ~ts", [IncludedAtFile])}.
+          hank_utils:format_text("This header file is only included at: ~ts", [IncludedAtFile]),
+      pattern => undefined}.
 
 build_include_list(FilesAndASTs) ->
     {Files, _ASTs} = lists:unzip(FilesAndASTs),
@@ -60,3 +61,10 @@ is_file_included(Files, IncludedFile) ->
         _ ->
             false
     end.
+
+%% @todo Add ignore pattern support
+-spec ignored(hank_rule:ignore_pattern(), term()) -> boolean().
+ignored(undefined, _IgnoreSpec) ->
+    false; %% Remove this clause and just use the one below
+ignored(_Pattern, _IgnoreSpec) ->
+    true.

--- a/src/rules/unnecessary_function_arguments.erl
+++ b/src/rules/unnecessary_function_arguments.erl
@@ -8,7 +8,7 @@
 
 -behaviour(hank_rule).
 
--export([analyze/2]).
+-export([analyze/2, ignored/2]).
 
 %% @private
 -spec analyze(hank_rule:asts(), hank_context:t()) -> [hank_rule:result()].
@@ -40,7 +40,8 @@ analyze_function(File, Function) ->
 set_result(File, {error, Line, Text}) ->
     #{file => File,
       line => Line,
-      text => Text};
+      text => Text,
+      pattern => undefined};
 set_result(_File, _) ->
     ok.
 
@@ -114,3 +115,10 @@ check_computed_results(FuncDesc, Line, Results) ->
 set_error(Line, Pos, FuncDesc) ->
     Text = hank_utils:format_text("~ts doesn't need its #~p argument", [FuncDesc, Pos]),
     {error, Line, Text}.
+
+%% @todo Add ignore pattern support
+-spec ignored(hank_rule:ignore_pattern(), term()) -> boolean().
+ignored(undefined, _IgnoreSpec) ->
+    false; %% Remove this clause and just use the one below
+ignored(_Pattern, _IgnoreSpec) ->
+    true.

--- a/src/rules/unnecessary_function_arguments.erl
+++ b/src/rules/unnecessary_function_arguments.erl
@@ -1,7 +1,7 @@
-%% @doc A rule to detect unneded function parameters.
-%%      <p>The rule emits a warning for each function parameter that is consistently
+%% @doc A rule to detect unnecessary function arguments.
+%%      <p>The rule emits a warning for each function argument that is consistently
 %%      ignored in all function clauses.</p>
-%%      <p>To avoid this warning, remove the unused parameter(s).</p>
+%%      <p>To avoid this warning, remove the unused argument(s).</p>
 %%      <p><b>Note:</b> This rule will not emit a warning if the function
 %%      implements a behaviour callback or a NIF call.</p>
 -module(unnecessary_function_arguments).
@@ -37,17 +37,15 @@ analyze_function(File, Function) ->
                 [],
                 check_function(Function)).
 
-set_result(File, {error, Line, Text}) ->
+set_result(File, {error, Line, Text, IgnorePattern}) ->
     #{file => File,
       line => Line,
       text => Text,
-      pattern => undefined};
+      pattern => IgnorePattern};
 set_result(_File, _) ->
     ok.
 
 check_function(FunctionNode) ->
-    Line = hank_utils:node_line(FunctionNode),
-    FuncDesc = hank_utils:function_description(FunctionNode),
     Clauses = erl_syntax:function_clauses(FunctionNode),
     ComputedResults =
         lists:foldl(fun(Clause, Result) ->
@@ -63,7 +61,7 @@ check_function(FunctionNode) ->
                     end,
                     [],
                     Clauses),
-    check_computed_results(FuncDesc, Line, ComputedResults).
+    check_computed_results(FunctionNode, ComputedResults).
 
 %% @doc Checks if the last expression in a clause body applies `erlang:nif_error/x`
 is_clause_a_nif_stub(Clause) ->
@@ -96,29 +94,35 @@ is_arg_ignored("_" ++ _) ->
 is_arg_ignored(_) ->
     0.
 
-check_computed_results(FuncDesc, Line, Results) ->
+check_computed_results(FunctionNode, Results) ->
     {_, Errors} =
-        lists:foldl(fun(Result, {Pos, Errors}) ->
+        lists:foldl(fun(Result, {ArgNum, Errors}) ->
                        NewErrors =
                            case Result of
                                0 ->
                                    Errors;
                                1 ->
-                                   [set_error(Line, Pos, FuncDesc) | Errors]
+                                   [set_error(FunctionNode, ArgNum) | Errors]
                            end,
-                       {Pos + 1, NewErrors}
+                       {ArgNum + 1, NewErrors}
                     end,
                     {1, []},
                     Results),
     Errors.
 
-set_error(Line, Pos, FuncDesc) ->
-    Text = hank_utils:format_text("~ts doesn't need its #~p argument", [FuncDesc, Pos]),
-    {error, Line, Text}.
+set_error(FuncNode, ArgNum) ->
+    Line = hank_utils:node_line(FuncNode),
+    FuncDesc = hank_utils:function_description(FuncNode),
+    Text = hank_utils:format_text("~ts doesn't need its #~p argument", [FuncDesc, ArgNum]),
+    FuncName = hank_utils:function_name(FuncNode),
+    IgnorePattern = {list_to_atom(FuncName), erl_syntax:function_arity(FuncNode), ArgNum},
+    {error, Line, Text, IgnorePattern}.
 
-%% @todo Add ignore pattern support
+%% @doc Ignore rule pattern matching
 -spec ignored(hank_rule:ignore_pattern(), term()) -> boolean().
-ignored(undefined, _IgnoreSpec) ->
-    false; %% Remove this clause and just use the one below
+ignored({FuncName, _, _}, FuncName) ->
+    true;
+ignored({FuncName, FuncArity, _}, {FuncName, FuncArity}) ->
+    true;
 ignored(_Pattern, _IgnoreSpec) ->
-    true.
+    false.

--- a/src/rules/unnecessary_function_arguments.erl
+++ b/src/rules/unnecessary_function_arguments.erl
@@ -118,7 +118,18 @@ set_error(FuncNode, ArgNum) ->
     IgnorePattern = {list_to_atom(FuncName), erl_syntax:function_arity(FuncNode), ArgNum},
     {error, Line, Text, IgnorePattern}.
 
-%% @doc Ignore rule pattern matching
+%% @doc Rule ignore specifications example:
+%%      <code>
+%%      -hank([{unnecessary_function_arguments,
+%%               %% You can give a list of multiple specs or a single one
+%%               [%% Will ignore any unused argument from `ignore_me/2` within the module
+%%                {ignore_me, 2},
+%%                %% Will ignore the 2nd argument from `ignore_me_too/3` within the module
+%%                {ignore_me_too, 3, 2},
+%%                %% Will ignore any unused argument from any `ignore_me_again/x`
+%%                %% within the module (no matter the function arity)
+%%                ignore_me_again]}]).
+%%      </code>
 -spec ignored(hank_rule:ignore_pattern(), term()) -> boolean().
 ignored({FuncName, _, _}, FuncName) ->
     true;

--- a/src/rules/unused_callbacks.erl
+++ b/src/rules/unused_callbacks.erl
@@ -16,7 +16,7 @@
 
 -behaviour(hank_rule).
 
--export([analyze/2]).
+-export([analyze/2, ignored/2]).
 
 %% @private
 -spec analyze(hank_rule:asts(), hank_context:t()) -> [hank_rule:result()].
@@ -60,4 +60,12 @@ set_result(File, Line, Callback, Arity) ->
       line => Line,
       text =>
           hank_utils:format_text("Callback ~tw/~B is not used anywhere in the module",
-                                 [Callback, Arity])}.
+                                 [Callback, Arity]),
+      pattern => undefined}.
+
+%% @todo Add ignore pattern support
+-spec ignored(hank_rule:ignore_pattern(), term()) -> boolean().
+ignored(undefined, _IgnoreSpec) ->
+    false; %% Remove this clause and just use the one below
+ignored(_Pattern, _IgnoreSpec) ->
+    true.

--- a/src/rules/unused_hrls.erl
+++ b/src/rules/unused_hrls.erl
@@ -6,7 +6,7 @@
 
 -behaviour(hank_rule).
 
--export([analyze/2]).
+-export([analyze/2, ignored/2]).
 
 %% @private
 -spec analyze(hank_rule:asts(), hank_context:t()) -> [hank_rule:result()].
@@ -18,7 +18,8 @@ analyze(FilesAndASTs, Context) ->
          || AST <- ASTs, IncludeLibPath <- include_lib_paths(AST)],
     [#{file => File,
        line => 0,
-       text => "This file is unused"}
+       text => "This file is unused",
+       pattern => undefined}
      || File <- Files,
         filename:extension(File) == ".hrl",
         is_unused_local(File, IncludePaths),
@@ -59,3 +60,10 @@ fname_join(["." | [_ | _] = Rest]) ->
     fname_join(Rest);
 fname_join(Components) ->
     filename:join(Components).
+
+%% @todo Add ignore pattern support
+-spec ignored(hank_rule:ignore_pattern(), term()) -> boolean().
+ignored(undefined, _IgnoreSpec) ->
+    false; %% Remove this clause and just use the one below
+ignored(_Pattern, _IgnoreSpec) ->
+    true.

--- a/src/rules/unused_macros.erl
+++ b/src/rules/unused_macros.erl
@@ -6,7 +6,7 @@
 
 -behaviour(hank_rule).
 
--export([analyze/2]).
+-export([analyze/2, ignored/2]).
 
 %% @private
 -spec analyze(hank_rule:asts(), hank_context:t()) -> [hank_rule:result()].
@@ -59,4 +59,12 @@ result(File, Name, Arity, Line) ->
         end,
     #{file => File,
       line => Line,
-      text => Text}.
+      text => Text,
+      pattern => undefined}.
+
+%% @todo Add ignore pattern support
+-spec ignored(hank_rule:ignore_pattern(), term()) -> boolean().
+ignored(undefined, _IgnoreSpec) ->
+    false; %% Remove this clause and just use the one below
+ignored(_Pattern, _IgnoreSpec) ->
+    true.

--- a/src/rules/unused_record_fields.erl
+++ b/src/rules/unused_record_fields.erl
@@ -8,7 +8,7 @@
 
 -behaviour(hank_rule).
 
--export([analyze/2]).
+-export([analyze/2, ignored/2]).
 
 %% @private
 -spec analyze(hank_rule:asts(), hank_context:t()) -> [hank_rule:result()].
@@ -107,7 +107,8 @@ result(File, RecordName, FieldName, RecordDefinitions) ->
     #{file => File,
       line => L,
       text =>
-          hank_utils:format_text("Field ~tp in record ~tp is unused", [FieldName, RecordName])}.
+          hank_utils:format_text("Field ~tp in record ~tp is unused", [FieldName, RecordName]),
+      pattern => undefined}.
 
 find_record_definition(RecordName, Definitions) ->
     lists:search(fun(Definition) ->
@@ -127,3 +128,10 @@ find_record_field(FieldName, Definitions) ->
                     FN == FieldName
                  end,
                  Definitions).
+
+%% @todo Add ignore pattern support
+-spec ignored(hank_rule:ignore_pattern(), term()) -> boolean().
+ignored(undefined, _IgnoreSpec) ->
+    false; %% Remove this clause and just use the one below
+ignored(_Pattern, _IgnoreSpec) ->
+    true.

--- a/test/global_rejector.erl
+++ b/test/global_rejector.erl
@@ -3,11 +3,16 @@
 
 -behaviour(hank_rule).
 
--export([analyze/2]).
+-export([analyze/2, ignored/2]).
 
 %% @doc All files are wrong!!
 analyze(ASTs, _) ->
     [#{file => File,
        line => 1,
-       text => "global_rejector"}
+       text => "global_rejector",
+       pattern => undefined}
      || {File, _} <- ASTs].
+
+-spec ignored(hank_rule:ignore_pattern(), term()) -> boolean().
+ignored(_Pattern, _IgnoreSpec) ->
+    false.

--- a/test/ignore_SUITE.erl
+++ b/test/ignore_SUITE.erl
@@ -67,7 +67,8 @@ hank_individual_rules(_Config) ->
 
     ct:comment("With -hank ignore, there should only be warnings for non-ignored "
                "rules"),
-    State1 = rebar_state:set(State, hank, [{rules, [unused_macros, global_rejector]}]),
+    Rules = [unused_macros, unnecessary_function_arguments, global_rejector],
+    State1 = rebar_state:set(State, hank, [{rules, Rules}]),
     Warnings = find_warnings(State1),
     [<<" global_rejector">>] =
         [Text

--- a/test/unnecessary_function_arguments_SUITE.erl
+++ b/test/unnecessary_function_arguments_SUITE.erl
@@ -1,10 +1,10 @@
 -module(unnecessary_function_arguments_SUITE).
 
 -export([all/0, init_per_testcase/2, end_per_testcase/2]).
--export([with_warnings/1, without_warnings/1, macros/1]).
+-export([with_warnings/1, without_warnings/1, macros/1, ignore/1]).
 
 all() ->
-    [with_warnings, without_warnings, macros].
+    [with_warnings, without_warnings, macros, ignore].
 
 init_per_testcase(_, Config) ->
     hank_test_utils:init_per_testcase(Config, "unnecessary_function_arguments").
@@ -48,7 +48,17 @@ macros(_Config) ->
     [#{file := "macros.erl",
        line := 4,
        text := <<"?MODULE/1 doesn't need its #1 argument">>}] =
-        analyze(["macros.erl"]).
+        analyze(["macros.erl"]),
+    ok.
+
+%% @doc Hank should correctly ignore warnings
+ignore(_Config) ->
+    ct:comment("Should correctly ignore warnings"),
+    [#{file := "ignore.erl",
+       line := 16,
+       text := <<"ignore_arg2/2 doesn't need its #2 argument">>}] =
+        analyze(["ignore.erl"]),
+    ok.
 
 analyze(Files) ->
     hank_test_utils:analyze_and_sort(Files, [unnecessary_function_arguments]).


### PR DESCRIPTION
The idea is that each rule must implement the callback `ignored/2` that will receive:
* An "ignore pattern" (`undefined | tuple()`) internally set by each rule.
It will have useful data to pattern match in a later stage when ignoring warnings.
* An "ignore spec" (`term()` to be "generic" enough) that is taken from `-hank` attributes
It will define the values to be pattern matched against the "ignore pattern" defined above.

Added the `pattern` property (`undefined | tuple()`) to `hank_rule:result/0` type and setting it as `undefined` in all current existing rules.

---

Did the first ignore implementation for `unnecessary_function_arguments` rule and seems to be pretty straightforward.
We might need to adjust things a little bit when adding the ignore implementation for other rules, but it should be generic enough to only need minimal adjustments.

---

The "ignore spec"  is explained in this example (including the implemented for `unnecessary_function_arguments`):
```
-hank([unused_macros,  %% This will keep ignoring the whole rule, just as before
       {unused_callbacks, cb_func_name_to_ignore}  %% When implemented, it should ignore the given cb func name
       {unnecessary_function_arguments,  %% You can give a list of multiple specs (or a single one like above)
           [{ignore_me, 2},  %% Will ignore any unused argument from `ignore_me/2`
            {ignore_me_too, 3, 2},  %% Will ignore the 2nd argument from `ignore_me_too/3`
            ignore_me_again]}]). %% Will ignore any unused argument from any `ignore_me_again/x` (no matter the arity)
```

**IMPORTANT NOTE:** It **only** support to give specific items to be ignored at `-hank` module attribute.
From config, it stays the same as before, the user can ignore entire rules from specific files.
It doesn't make much sense to me to have the same level of "ignore detail" at config because you would be adding specific functions and/or any other module-specific code definition at config level (in where one expects to be "abstracted" from such a detail level).
It think it's a best practice to "force" the developer to define specific ignore rules within the same module that you want to ignore specific items and that's it.
If you think folks that we should also add this support at config level, just LMK!