### PR TITLE
Fix #82: Handle macros with the same name as a callback

### DIFF
--- a/src/hank_utils.erl
+++ b/src/hank_utils.erl
@@ -155,7 +155,7 @@ node_atoms(Nodes) ->
                    MacroName = erl_syntax:macro_name(Node),
                    case erl_syntax:type(MacroName) of
                        atom ->
-                           %% Note that this erl_syntax_lib:fold/3 works in a DFS manner.
+                           %% Note that erl_syntax_lib:fold/3 works in a DFS manner.
                            %% That's why our macro-skipping trick works:
                            %%   it removes the atom that was previously introduced
                            %%   into the accumulator.

--- a/test/unused_callbacks_SUITE.erl
+++ b/test/unused_callbacks_SUITE.erl
@@ -24,15 +24,14 @@ with_warnings(_Config) ->
     ok.
 
 %% @doc Hank finds unused callbacks with macros
-%% @todo [#81 + #82] Correctly handle macros
 with_macros(_Config) ->
     ct:comment("Should detect and display warnings for unused callbacks with macros"),
 
-    % File = "macros.erl",
-    % [#{file := File,
-    %    line := 4,
-    %    text := <<"Callback unused_callback/0 is not used anywhere in the module">>}] =
-    %     analyze([File]),
+    File = "macros.erl",
+    [#{file := File,
+       line := 4,
+       text := <<"Callback unused_callback/0 is not used anywhere in the module">>}] =
+        analyze([File]),
     ok.
 
 %% @doc Hank finds nothing!


### PR DESCRIPTION
Fix #82: Handle macros with the same name as a callback