### PR TITLE
#88: Add possibility to ignore config options by config file

### DIFF
--- a/priv/test_files/test_app/sys.config
+++ b/priv/test_files/test_app/sys.config
@@ -1,7 +1,8 @@
 [
     {test_app, [
         {environment, test},
-        {a_key, ok}
+        {a_key, ok},
+        {not_used_but_ignored, hum}
     ]},
     "another_sys.config"
 ].

--- a/src/rebar3_hank_prv.erl
+++ b/src/rebar3_hank_prv.erl
@@ -93,11 +93,11 @@ get_rules(State) ->
     end.
 
 normalize(IgnoreRules) ->
-    lists:map(fun ({Wildcard, Rule}) ->
-                      {Wildcard, Rule, []};
-                  ({Wildcard, Rule, Options}) ->
+    lists:map(fun ({Wildcard, Rule, Options}) ->
                       {Wildcard, Rule, Options};
+                  ({Wildcard, Rule}) ->
+                      {Wildcard, Rule, all};
                   (Wildcard) ->
-                      {Wildcard, all, []}
+                      {Wildcard, all, all}
               end,
               IgnoreRules).

--- a/src/rules/unused_configuration_options.erl
+++ b/src/rules/unused_configuration_options.erl
@@ -89,12 +89,10 @@ result(File, Option) ->
     #{file => File,
       line => 0,
       text => hank_utils:format_text("~tw is not used anywhere in the code", [Option]),
-      pattern => undefined}.
+      pattern => {File, Option}}.
 
-%% @TODO Add ignore pattern support
-%% https://github.com/AdRoll/rebar3_hank/issues/84
 -spec ignored(hank_rule:ignore_pattern(), term()) -> boolean().
-ignored(undefined, _IgnoreSpec) ->
-    false; %% Remove this clause and just use the one below
-ignored(_Pattern, _IgnoreSpec) ->
-    true.
+ignored({_File, Option}, Option) ->
+    true;
+ignored(_, _) ->
+    false.

--- a/test/single_use_hrls_SUITE.erl
+++ b/test/single_use_hrls_SUITE.erl
@@ -46,7 +46,7 @@ respects_ignore(_) ->
          "src/include_multi.erl",
          "src/include_single.erl",
          "src/include_ignored.erl"],
-    [] = analyze(Files, [{"include/single.hrl", all, []}]),
+    [] = analyze(Files, [{"include/single.hrl", all, all}]),
     ok.
 
 %% @doc Hank ignores header files that aren't present in the list of analyzed files

--- a/test/single_use_hrls_SUITE.erl
+++ b/test/single_use_hrls_SUITE.erl
@@ -46,7 +46,7 @@ respects_ignore(_) ->
          "src/include_multi.erl",
          "src/include_single.erl",
          "src/include_ignored.erl"],
-    [] = analyze(Files, [{"include/single.hrl", all}]),
+    [] = analyze(Files, [{"include/single.hrl", all, []}]),
     ok.
 
 %% @doc Hank ignores header files that aren't present in the list of analyzed files

--- a/test/test_app_SUITE.erl
+++ b/test/test_app_SUITE.erl
@@ -39,7 +39,9 @@ without_warnings(_Config) ->
     ct:comment("Without the global rejector, there should be no warnings either"),
     Rules = hank_rule:default_rules() -- [global_rejector],
     State3 = hank_test_utils:init(test_app),
-    State4 = rebar_state:set(State3, hank, [{rules, Rules}]),
+    IgnorePattern =
+        {ignore, [{"sys.config", unused_configuration_options, [not_used_but_ignored]}]},
+    State4 = rebar_state:set(State3, hank, [{rules, Rules}, IgnorePattern]),
     {ok, _} = rebar3_hank_prv:do(State4),
 
     {comment, ""}.


### PR DESCRIPTION
This adds support for the #88 feature.

You can add in your `rebar.config` hank ignores:
```
{hank,
 [{ignore, [
    {"sys.config", unused_configuration_options, [not_used_but_ignored]}
  ]}]}
```