### PR TITLE
Add benchmarking and actually improve timings

### DIFF
--- a/test/hank_test_utils.erl
+++ b/test/hank_test_utils.erl
@@ -41,9 +41,15 @@ analyze_and_sort(Files, IgnoredFiles, Rules) ->
     analyze_and_sort(Files, IgnoredFiles, Rules, mock_context(#{}, [])).
 
 analyze_and_sort(Files, IgnoredFiles, Rules, Context) ->
-    Results = hank:analyze(Files, IgnoredFiles, Rules, Context),
-    lists:sort(
-        maps:get(results, Results)).
+    #{stats := Stats, results := Results} = hank:analyze(Files, IgnoredFiles, Rules, Context),
+    #{parsing := Parsing,
+      analyzing := Analyzing,
+      total := Total} =
+        Stats,
+    {true, Stats} = {Parsing >= 0, Stats},
+    {true, Stats} = {Analyzing >= 0, Stats},
+    {true, Stats} = {Parsing + Analyzing =< Total, Stats},
+    lists:sort(Results).
 
 set_cwd(RelativePathOrFilename) ->
     ok = file:set_cwd(abs_test_path(RelativePathOrFilename)).


### PR DESCRIPTION
Thanks to @lauramcastro's dedication to the completeness of our paper, I actually benchmarked Hank and the results were… not what you would've expected…

# 😱 

|                               | Erlang/OTP   | Kazoo     | MongooseIM |
|-------------------------------|-------------:|----------:|-----------:|
|Size of project (in SLOC)      | `> 2M`       | `> 400K`  | `> 180K`   |
| | | | |
|Sequential File Parsing        | `29042ms`    | `3457ms`  | `1735ms`   |
|Parallel File Parsing          | **`8751ms`**     | **`959ms`**   | **`490ms`**    |
| | | | |
|Sequential Rule Evaluation     | **`150274ms`**   | **`6818ms`**  | **`2430ms`**   |
|Parallel Rule Evaluation       | `156136ms`   | `10678ms` | `2788ms`   |
| | | | |
|Total Sequential Runtime       | `181750ms`   | `10665ms` | `4372ms`   |
|Total Parallel Runtime         | `168057ms`   | `12101ms` | `3635ms`   |
| | | | |
|**Total Optimal Runtime**      | **`162424ms`**   | **`8360ms`**  | **`3393ms`**   |

In a nutshell, file parsing was greatly improved by using parallel execution, but rule evaluation was actually faster if performed sequentially. That may be unintuitive, but it can be explained by the fact that there are very few rules and none of them are bound by I/O or network processing. That's why the time spent by `rpc:pmap/3` spawning processes, waiting for results, and collating responses outweighs the time spent actually running the algorithms.

So, the _Optimal_ version you see in this PR removes parallelism from rule evaluation and gets us to the faster version of Hank ever.
