### PR TITLE
Fix #130: Avoid emitting a warning if an attribute is used only where it's defined

### DIFF
--- a/test/files/single_use_hrl_attrs/lib/app/include/header1.hrl
+++ b/test/files/single_use_hrl_attrs/lib/app/include/header1.hrl
@@ -1,3 +1,4 @@
 -define(APP_HEADER_1, "this is header from app that will be used in just one module").
 -define(SOME_MACRO_1(A), A).
--define(SOME_DEFINE, ok).
+-define(THIS_MACRO, {is_used, "and", it, shouldnt, generate, a, warning}).
+-define(SOME_DEFINE, ?THIS_MACRO).


### PR DESCRIPTION
Fix #130: Avoid emitting a warning if an attribute is used only where it's defined