### PR TITLE
Fix #134: Do not break when the behaviour is a macro

### DIFF
--- a/src/rebar3_hank.app.src
+++ b/src/rebar3_hank.app.src
@@ -1,7 +1,7 @@
 {application,
  rebar3_hank,
  [{description, "A rebar plugin for dead code cleaning"},
-  {vsn, "1.1.1"},
+  {vsn, "1.1.2"},
   {registered, []},
   {applications, [kernel, stdlib, katana_code]},
   {env, []},

--- a/test/files/unnecessary_function_arguments/a_behaviour_imp.erl
+++ b/test/files/unnecessary_function_arguments/a_behaviour_imp.erl
@@ -13,6 +13,6 @@ a_kind_of_magic(_) ->
     % this function won't be warned since it's a callback
     implemented.
 
-%% this will warn
+%% this won't warn because the whole file implementing a local behaviour is ignored
 function_with_ignored_arg(_, Value) ->
     Value.

--- a/test/files/unnecessary_function_arguments/macro_behaviour_imp.erl
+++ b/test/files/unnecessary_function_arguments/macro_behaviour_imp.erl
@@ -1,7 +1,7 @@
 %% @doc This module is a nasty case, it implements a behaviour inside a macro
 -module(macro_behaviour_imp).
 
--define(WHY_DO_YOU_DO_THIS_TO_ME, a_behaviour)
+-define(WHY_DO_YOU_DO_THIS_TO_ME, a_behaviour).
 
 -behaviour(?WHY_DO_YOU_DO_THIS_TO_ME).
 

--- a/test/unnecessary_function_arguments_SUITE.erl
+++ b/test/unnecessary_function_arguments_SUITE.erl
@@ -21,7 +21,6 @@ with_warnings(_Config) ->
     FileB = "warnings_B.erl",
     FileC = "a_behaviour.erl",
     FileD = "gen_server_imp.erl",
-    FileE = "a_behaviour_imp.erl",
     [#{file := FileC,
        text := <<"a_function_from_the_behaviour/1 doesn't need its #1 argument">>},
      #{file := FileD, text := <<"my_function/1 doesn't need its #1 argument">>},
@@ -31,13 +30,18 @@ with_warnings(_Config) ->
      #{file := FileA, text := <<"unicode_αβåö/1 doesn't need its #1 argument"/utf8>>},
      #{file := FileA, text := <<"with_nif_stub/2 doesn't need its #1 argument">>},
      #{file := FileB, text := <<"underscore/3 doesn't need its #1 argument">>}] =
-        analyze([FileA, FileB, FileC, FileD, FileE, "a_behaviour_imp.erl"]),
+        analyze([FileA, FileB, FileC, FileD, "a_behaviour_imp.erl", "macro_behaviour_imp.erl"]),
     ok.
 
 %% @doc Hank finds nothing!
 without_warnings(_Config) ->
     ct:comment("Should not detect anything since the files are clean from warnings"),
-    [] = analyze(["weird.erl", "clean.erl", "nifs.erl", "a_behaviour_imp.erl"]),
+    [] =
+        analyze(["weird.erl",
+                 "clean.erl",
+                 "nifs.erl",
+                 "a_behaviour_imp.erl",
+                 "macro_behaviour_imp.erl"]),
     ok.
 
 %% @doc Macros as function names should work


### PR DESCRIPTION
Fixes #134 

For now, proposed solution is ignoring the whole file if the behaviour is a macro.
