### PR TITLE
Fix #165: Don't emit warnings for unused ignores.

### DIFF
--- a/test/unused_ignores_SUITE.erl
+++ b/test/unused_ignores_SUITE.erl
@@ -19,8 +19,7 @@ unused_ignores(_) ->
     IgnoreSpecs = [{"ignore_config.erl", unused_macros, ["MACRO_FROM_CONFIG"]}],
     #{results := [],
       unused_ignores :=
-          [{"ignore_all.erl", unused_macros, all},
-           {"ignore_config.erl", unused_macros, ["MACRO_FROM_CONFIG"]},
+          [{"ignore_config.erl", unused_macros, ["MACRO_FROM_CONFIG"]},
            {"unused_ignores.erl", bad_rule, all},
            {"unused_ignores.erl",
             unnecessary_function_arguments,


### PR DESCRIPTION
If the file ignores hank entirely, either by using  or being part of a  wildcard, don't emit a warning for the rules it's excessively ignoring.

In other words, I implemented the full solution that @paulo-ferraz-oliveira and @pbrudnick were looking for. It was simpler than what I anticipated.