### PR TITLE
Add rebar3_ex_doc plugin

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -17,11 +17,21 @@
 
 {deps, [{katana_code, "~> 1.2.0"}]}.
 
+{ex_doc,
+ [{source_url, <<"https://github.com/AdRoll/rebar3_hank">>},
+  {extras, [<<"README.md">>, <<"LICENSE">>]},
+  {main, <<"readme">>}]}.
+
+% Integrating with rebar3_hex
+% See https://hexdocs.pm/rebar3_ex_doc/readme.html#integrating-with-rebar3_hex
+{hex, [{doc, #{provider => ex_doc}}]}.
+
 {project_plugins,
  [{rebar3_hex, "~> 7.0.1"},
   {rebar3_format, "~> 1.0.1"},
   {rebar3_lint, "~> 1.0.1"},
-  {rebar3_sheldon, "~> 0.4.2"}]}.
+  {rebar3_sheldon, "~> 0.4.2"},
+  rebar3_ex_doc]}.
 
 {dialyzer, [{warnings, [no_return, unmatched_returns, error_handling, underspecs]}]}.
 


### PR DESCRIPTION
Trying [rebar3_ex_doc](https://hexdocs.pm/rebar3_ex_doc/readme.html) new plugin to have ExDoc docs.

Based on: https://twitter.com/josevalim/status/1480815810503495683

Needs OTP 24