### PR TITLE
Feature: Store hank output in json file

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ By default, Hank will emit warnings such as the following ones if you are ignori
 
 It's worth noting that, even when those warnings are printed, that doesn't affect the overall result of the command. That is, if Hank can't find any instances of oxbow code, it will return successfully (i.e. `exit code: 0`) even when it may print these warnings.
 
-By default, if hank detect issues in your code, it will print those issue on the console. But you can save this result in JSON format,
+By default, if Hank detect issues in your code, it will print those issues on the console. But you can save this result in a file (in JSON format),
 by using `--output_json_file=output_filename.json`.
 
 ```markdown

--- a/README.md
+++ b/README.md
@@ -61,12 +61,18 @@ $ rebar3 help hank
 
 Usage: rebar3 hank [-u <unused_ignores>]
 
-  -u, --unused_ignores  Warn on unused ignores (default: true).
+  Usage: rebar3 hank [-u <unused_ignores>] [-o <output_json_file>]
+
+  -u, --unused_ignores    Warn on unused ignores (default: true).
+  -o, --output_json_file  Emit output (in JSON format) to a file (default: empty string - meaning: donot emit output
 
 ```
 By default, Hank will emit warnings such as the following ones if you are ignoring rules that you don't need to ignore (more on that below). But you can turn those warnings off, by using `--unused_ignores=no`.
 
 It's worth noting that, even when those warnings are printed, that doesn't affect the overall result of the command. That is, if Hank can't find any instances of oxbow code, it will return successfully (i.e. `exit code: 0`) even when it may print these warnings.
+
+By default, if hank detect issues in your code, it will print those issue on the console. But you can save this result in JSON format,
+by using `--output_json_file=output_filename.json`.
 
 ```markdown
 ===> The following ignore specs are no longer needed and can be removed:

--- a/rebar.config
+++ b/rebar.config
@@ -18,7 +18,7 @@
   {rebar3_lint, "~> 1.0.2"},
   {rebar3_sheldon, "~> 0.4.2"},
   {rebar3_ex_doc, "~> 0.2.9"},
-  {jsx, "~> 2.10"}]}.
+  {jsx, "~> 3.1.0"}]}.
 
 {dialyzer, [{warnings, [no_return, unmatched_returns, error_handling, underspecs]}]}.
 

--- a/rebar.config
+++ b/rebar.config
@@ -17,7 +17,8 @@
   {rebar3_format, "~> 1.2.0"},
   {rebar3_lint, "~> 1.0.2"},
   {rebar3_sheldon, "~> 0.4.2"},
-  {rebar3_ex_doc, "~> 0.2.9"}]}.
+  {rebar3_ex_doc, "~> 0.2.9"},
+  {jsx, "~> 2.10"}]}.
 
 {dialyzer, [{warnings, [no_return, unmatched_returns, error_handling, underspecs]}]}.
 

--- a/src/hank_rule.erl
+++ b/src/hank_rule.erl
@@ -51,14 +51,12 @@ is_ignored(Rule, Pattern, IgnoreSpec) ->
 
 -spec result_to_json(hank_rule:result()) -> map().
 result_to_json(Data) ->
-   #{file := FileName, line := Line, rule := RuleBroken, text := Description} = Data,
-   #{
-       <<"path">> => iolist_to_binary(FileName),
-       <<"start_line">> => Line,
-       <<"hank_rule_broken">> => atom_to_binary(RuleBroken),
-       <<"title">> => compute_title(RuleBroken),
-       <<"message">> => iolist_to_binary(Description)
-    }.
+    #{file := FileName, line := Line, rule := RuleBroken, text := Description} = Data,
+    #{<<"path">> => iolist_to_binary(FileName),
+      <<"start_line">> => Line,
+      <<"hank_rule_broken">> => atom_to_binary(RuleBroken),
+      <<"title">> => compute_title(RuleBroken),
+      <<"message">> => iolist_to_binary(Description)}.
 
 -spec compute_title(atom()) -> binary().
 compute_title(RuleBroken) ->
@@ -66,9 +64,9 @@ compute_title(RuleBroken) ->
         unused_macros ->
             <<"Unused Macros">>;
         single_use_hrl_attrs ->
-            <<"Macro is only used once">>;
+            <<"Macro only used once">>;
         unused_record_fields ->
-            <<"Field in the record is unused">>;
+            <<"Unused field in record">>;
         unused_hrls ->
             <<"Unused hrl files">>;
         unused_configuration_options ->
@@ -76,7 +74,7 @@ compute_title(RuleBroken) ->
         unused_callbacks ->
             <<"Unused callback functions">>;
         unnecessary_function_arguments ->
-            <<"Unused function arguments found">>;
+            <<"Unused function arguments">>;
         single_use_hrls ->
-            <<"Hrl is only used once">>
+            <<"Hrl file only used once">>
     end.

--- a/src/hank_rule.erl
+++ b/src/hank_rule.erl
@@ -57,7 +57,7 @@ result_to_json(Data) ->
        <<"start_line">> => Line,
        <<"hank_rule_broken">> => atom_to_binary(RuleBroken),
        <<"title">> => compute_title(RuleBroken),
-       <<"message">> => Description
+       <<"message">> => iolist_to_binary(Description)
     }.
 
 -spec compute_title(atom()) -> binary().

--- a/src/hank_rule.erl
+++ b/src/hank_rule.erl
@@ -20,6 +20,7 @@
 -export([default_rules/0]).
 -export([analyze/3]).
 -export([is_ignored/3]).
+-export([result_to_json/1]).
 
 %% @doc The list of default rules to apply
 -spec default_rules() -> [].
@@ -47,3 +48,35 @@ analyze(Rule, ASTs, Context) ->
 -spec is_ignored(t(), ignore_pattern(), all | term()) -> boolean().
 is_ignored(Rule, Pattern, IgnoreSpec) ->
     IgnoreSpec =:= all orelse Rule:ignored(Pattern, IgnoreSpec).
+
+-spec result_to_json(hank_rule:result()) -> map().
+result_to_json(Data) ->
+   #{file := FileName, line := Line, rule := RuleBroken, text := Description} = Data,
+   #{
+       <<"path">> => iolist_to_binary(FileName),
+       <<"start_line">> => Line,
+       <<"hank_rule_broken">> => atom_to_binary(RuleBroken),
+       <<"title">> => compute_title(RuleBroken),
+       <<"message">> => Description
+    }.
+
+-spec compute_title(atom()) -> binary().
+compute_title(RuleBroken) ->
+    case RuleBroken of
+        unused_macros ->
+            <<"Unused Macros">>;
+        single_use_hrl_attrs ->
+            <<"Macro is only used once">>;
+        unused_record_fields ->
+            <<"Field in the record is unused">>;
+        unused_hrls ->
+            <<"Unused hrl files">>;
+        unused_configuration_options ->
+            <<"Unused config">>;
+        unused_callbacks ->
+            <<"Unused callback functions">>;
+        unnecessary_function_arguments ->
+            <<"Unused function arguments found">>;
+        single_use_hrls ->
+            <<"Hrl is only used once">>
+    end.

--- a/src/rebar3_hank_prv.erl
+++ b/src/rebar3_hank_prv.erl
@@ -75,7 +75,7 @@ do(State) ->
           unused_ignores := UnusedIgnores,
           stats := Stats} ->
             instrument(Stats, UnusedIgnores, State),
-            write_data_to_json_file(Results, State),
+            maybe_write_data_to_json_file(Results, State),
             {error, format_results(Results)}
     catch
         Kind:Error:Stack ->
@@ -127,8 +127,8 @@ format_result(#{file := File,
                 text := Msg}) ->
     hank_utils:format_text("~ts:~tp: ~ts", [File, Line, Msg]).
 
--spec write_data_to_json_file([hank_rule:result()], rebar_state:t()) -> ok.
-write_data_to_json_file(Result, State) ->
+-spec maybe_write_data_to_json_file([hank_rule:result()], rebar_state:t()) -> ok.
+maybe_write_data_to_json_file(Result, State) ->
     {Args, _} = rebar_state:command_parsed_args(State),
     case lists:keyfind(output_json_file, 1, Args) of
         {output_json_file, JsonFilePath} ->

--- a/src/rebar3_hank_prv.erl
+++ b/src/rebar3_hank_prv.erl
@@ -130,25 +130,18 @@ format_result(#{file := File,
 -spec write_data_to_json_file([hank_rule:result()], rebar_state:t()) -> ok.
 write_data_to_json_file(Result, State) ->
     {Args, _} = rebar_state:command_parsed_args(State),
-    JsonFilePath =
-        case lists:keyfind(output_json_file, 1, Args) of
-            {output_json_file, Value} ->
-                Value;
-            _ ->
-                undefined
-        end,
-    case JsonFilePath of
-        undefined ->
-            ok;
-        FilePath ->
-            case valid_json_format(FilePath) of
+    case lists:keyfind(output_json_file, 1, Args) of
+        {output_json_file, JsonFilePath} ->
+            case valid_json_format(JsonFilePath) of
                 true ->
                     ConvertedResult = convert_data_to_binary(Result),
                     EncodedResult = jsx:encode(ConvertedResult),
-                    ok = file:write_file(FilePath, EncodedResult);
+                    ok = file:write_file(JsonFilePath, EncodedResult);
                 false ->
                     ok
-            end
+            end;
+        _ ->
+            ok
     end.
 
 -spec valid_json_format(string()) -> boolean().

--- a/src/rebar3_hank_prv.erl
+++ b/src/rebar3_hank_prv.erl
@@ -40,7 +40,7 @@ opts() ->
         $o,
         "output_json_file",
         string,
-        "Emit output (in JSON format) to a file (default: empty string - meaning: donot emit output"}
+        "Emit output (in JSON format) to a file (default: empty string, meaning: do not emit output"}
     ].
 
 %% @private

--- a/src/rebar3_hank_prv.erl
+++ b/src/rebar3_hank_prv.erl
@@ -130,13 +130,19 @@ format_result(#{file := File,
 -spec maybe_write_data_to_json_file([hank_rule:result()], rebar_state:t()) -> ok.
 maybe_write_data_to_json_file(Result, State) ->
     {Args, _} = rebar_state:command_parsed_args(State),
+    ConvertedResult = convert_data_to_binary(Result),
+    EncodedResult = jsx:encode(ConvertedResult),
     case lists:keyfind(output_json_file, 1, Args) of
         {output_json_file, JsonFilePath} ->
-            ConvertedResult = convert_data_to_binary(Result),
-            EncodedResult = jsx:encode(ConvertedResult),
             ok = file:write_file(JsonFilePath, EncodedResult);
         _ ->
-            ok
+            JsonFilePassed = proplists:get_value(output_json_file, rebar_state:get(State, hank, []), []),
+            case JsonFilePassed of
+                [] ->
+                    ok;
+                _ ->
+                    ok = file:write_file(JsonFilePassed, EncodedResult)
+            end
     end.
 
 -spec convert_data_to_binary([hank_rules:result()]) -> list().


### PR DESCRIPTION
Provided an argument based option where if command is run like:
rebar3 hank -o "output.json"
then it stores the generated output of hank in the json file.
This json file can further be used for better analysis of dead code.


Sample Json:
```
[
  {
    "hank_rule_broken": "unnecessary_function_arguments",
    "message": "hello_world/2 doesn't need its #2 argument",
    "path": "apps/library/src/library_app.erl",
    "start_line": 19,
    "title": "Unused function arguments"
  },
  {
    "hank_rule_broken": "unused_hrls",
    "message": "This file is unused",
    "path": "apps/library/src/demo_var.hrl",
    "start_line": 0,
    "title": "Unused hrl files"
  }
]
```